### PR TITLE
Issue 1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Issue / Ticket
+
+- https://github.com/%USERNAME%/%REPONAME%/issues/%N%
+
+## What I did
+
+- ...
+- ...
+- ...
+
+## What I leave
+
+- ...
+
+## What the users become able to do
+
+- ...
+
+## What the users become unable to do
+
+- ...
+
+## How I checked the operation and the result
+
+- ...
+
+## Others
+
+- ...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
-
+ps1.txt
+bat.txt

--- a/ConvertTo-BatchFile.ps1
+++ b/ConvertTo-BatchFile.ps1
@@ -46,11 +46,6 @@ foreach($line in (Get-Content -Path $SourceFile)) {
     $line = $line.Replace(">", "^>");
     $line = $line.Replace("%", "%%");
 
-    # TODO:
-    # - ヒアドキュメントでもダブルクォート文字列中でも、エスケープ文字がそのままになってしまっている。
-    # - 変数展開
-    # - クォート文字重ね
-
     # ヒアドキュメントの処理
     # ヒアドキュメントは対応していないので、すべて1列の文字列に置き換える
     if ($inHereDoc) {

--- a/Execute-Test.bat
+++ b/Execute-Test.bat
@@ -1,0 +1,12 @@
+@ECHO OFF
+
+SET _CONVERTER=.\ConvertTo-BatchFile.ps1
+SET _TESTER=.\SampleCode.ps1
+SET _TESTER_BAT=.\SampleCode.bat
+SET _RESULT_PS1=.\ps1.txt
+SET _RESULT_BAT=.\bat.txt
+
+powershell -ExecutionPolicy ByPass -File %_CONVERTER% -SourceFile %_TESTER% -DestinationFile %_TESTER_BAT%
+
+powershell -ExecutionPolicy ByPass -File %_TESTER% > %_RESULT_PS1%
+%_TESTER_BAT% > %_RESULT_BAT%

--- a/SampleCode.bat
+++ b/SampleCode.bat
@@ -13,10 +13,16 @@ Add-Type -AssemblyName 'System.Windows.Forms'; ^
  ^
 $intVar = 48; ^
  ^
-$msgHereDoc = 'Set-PSDebug -Strict;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '`$var = ' + [char]0x22 + 'Hello World!' + [char]0x22 + ';' + ([Environment]::NewLine) + 'Write-Host -Object `$var;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '`$intVar = {0};' -F $intVar; ^
+$msgHereDoc = ('Set-PSDebug -Strict;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$var = ' + [char]0x22 + 'Hello World!' + [char]0x22 + ';' + ([Environment]::NewLine) + 'Write-Host -Object $var;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$intVar = {0};' + ([Environment]::NewLine) + '$quote = "o""o";' + ([Environment]::NewLine) + '`dir`' + ([Environment]::NewLine) + 'a' + [char]0x0a + 'b' + [char]0x0d + 'c' + ([Environment]::NewLine) + '') -F $intVar; ^
+ ^
+$msgDQuoted = '' + [char]0x22 + 'Hello World' + [char]0x22 + '' + [char]0x0a + '$1 = \135'; ^
+ ^
+$msgDupDQuote = 'A''A'; ^
+$msgDupSQuote = 'B''B'; ^
  ^
 Write-Host -Object $msgHereDoc; ^
- ^
+$msgDQuoted ^| Write-Host; ^
+@($msgDupDQuote, $msgDupSQuote) ^| %% { Write-Host -Object $_ } ^
  ^
 $prop = Get-ItemProperty -Path 'HKCU:Environment'; ^
 Write-Host -Object $prop.Path; ^

--- a/SampleCode.bat
+++ b/SampleCode.bat
@@ -2,27 +2,29 @@
 
 @SET CODE= ^
 Param( ^
-    [Parameter(Mandatory = $true)] ^
-    [string] $Message ^
+    [Parameter(Mandatory = $false)] ^
+    [string] $Message = [string]::Empty ^
 ); ^
  ^
 Set-PSDebug -Strict; ^
  ^
 Add-Type -AssemblyName 'System.Windows.Forms'; ^
-[Windows.Forms.MessageBox]::Show($Message) ^| Out-Null; ^
+if ($Message -ne [string]::Empty) { ^
+    [Windows.Forms.MessageBox]::Show($Message) ^| Out-Null; ^
+}; ^
  ^
 $intVar = 48; ^
  ^
-$msgHereDoc = ('Set-PSDebug -Strict;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$var = ' + [char]0x22 + 'Hello World!' + [char]0x22 + ';' + ([Environment]::NewLine) + 'Write-Host -Object $var;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$intVar = {0};' + ([Environment]::NewLine) + '$quote = "o""o";' + ([Environment]::NewLine) + '`dir`' + ([Environment]::NewLine) + 'a' + [char]0x0a + 'b' + [char]0x0d + 'c' + ([Environment]::NewLine) + '') -F $intVar; ^
+$msgHereDoc = ('Set-PSDebug -Strict;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$var = ' + [char]0x22 + 'Hello World!' + [char]0x22 + ';' + ([Environment]::NewLine) + 'Write-Host -Object $var;' + ([Environment]::NewLine) + '' + ([Environment]::NewLine) + '$intVar = {0};' + ([Environment]::NewLine) + '$quote = ' + [char]0x22 + 'o' + [char]0x22 + '' + [char]0x22 + 'o' + [char]0x22 + ';' + ([Environment]::NewLine) + '`dir`' + ([Environment]::NewLine) + 'a' + [char]0x0a + 'b' + [char]0x0d + 'c' + ([Environment]::NewLine) + '') -F $intVar; ^
  ^
 $msgDQuoted = '' + [char]0x22 + 'Hello World' + [char]0x22 + '' + [char]0x0a + '$1 = \135'; ^
  ^
-$msgDupDQuote = 'A''A'; ^
+$msgDupDQuote = 'A' + [char]0x22 + 'A'; ^
 $msgDupSQuote = 'B''B'; ^
  ^
 Write-Host -Object $msgHereDoc; ^
 $msgDQuoted ^| Write-Host; ^
-@($msgDupDQuote, $msgDupSQuote) ^| %% { Write-Host -Object $_ } ^
+@($msgDupDQuote, $msgDupSQuote) ^| %% { Write-Host -Object $_ }; ^
  ^
 $prop = Get-ItemProperty -Path 'HKCU:Environment'; ^
 Write-Host -Object $prop.Path; ^

--- a/SampleCode.ps1
+++ b/SampleCode.ps1
@@ -17,10 +17,20 @@ Set-PSDebug -Strict;
 Write-Host -Object `$var;
 
 `$intVar = {0};
+`$quote = "o""o";
+``dir``
+a`nb`rc
+
 "@ -F $intVar;
 
-Write-Host -Object $msgHereDoc;
+$msgDQuoted = "`"Hello World`"`n`$1 = \135";
 
+$msgDupDQuote = "A""A";
+$msgDupSQuote = 'B''B';
+
+Write-Host -Object $msgHereDoc;
+$msgDQuoted | Write-Host;
+@($msgDupDQuote, $msgDupSQuote) | % { Write-Host -Object $_ }
 
 $prop = Get-ItemProperty -Path "HKCU:Environment";
 Write-Host -Object $prop.Path;

--- a/SampleCode.ps1
+++ b/SampleCode.ps1
@@ -1,12 +1,14 @@
 Param(
-    [Parameter(Mandatory = $true)]
-    [string] $Message
+    [Parameter(Mandatory = $false)]
+    [string] $Message = [string]::Empty
 );
 
 Set-PSDebug -Strict;
 
 Add-Type -AssemblyName "System.Windows.Forms";
-[Windows.Forms.MessageBox]::Show($Message) | Out-Null;
+if ($Message -ne [string]::Empty) {
+    [Windows.Forms.MessageBox]::Show($Message) | Out-Null;
+}
 
 $intVar = 48;
 


### PR DESCRIPTION
## Issue / Ticket

- https://github.com/mori3works/pwsh-bat-converter/issues/1

## What I did

- ヒアドキュメントおよびダブルクォートで括られた文字列中で\`を伴う文字を指定した場合に適切に処理されない不具合を解消
- ダブルクォートで括られた文字列中のダブルクォートを重ねる方法でのダブルクォートの表現への対応
- シングルクォートで括られた文字列中のシングルクォートを重ねる方法でのシングルクォートの表現への対応
- ForEach-Objectを表す%を、%を重ねることでのエスケープ

## What I leave

特になし

## What the users become able to do

特になし

## What the users become unable to do

特になし

## How I checked the operation and the result

- SamepleCode.ps1からSampleCode.batを生成し、それぞれの実行結果を比較することで確認可能

## Others

特になし
